### PR TITLE
basic gradle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ $ docker run -p 25565:25565 minecraft-sample-plugin
 
     This variable specifies the arguments for Maven inside the container.
 
+*  **GRADLE_ARGS** (default: '')
+
+    This variable specifies the arguments for Gradle inside the container.
 
 ## Contributing
 

--- a/s2i/bin/assemble
+++ b/s2i/bin/assemble
@@ -3,16 +3,23 @@
 set -e
 
 cp -Rf /tmp/src/. ./
+mkdir ../mods/
 
-echo "---> Building plugin from source"
-echo "--> # MVN_ARGS = $MVN_ARGS"
-if [ -f "mvnw" ]; then
-  ./mvnw clean install $MVN_ARGS
-else
-  mvn clean install $MVN_ARGS
+if [ -f "./pom.xml" ]; then
+  echo "---> Building plugin from source"
+  echo "--> # MVN_ARGS = $MVN_ARGS"
+  if [ -f "mvnw" ]; then
+    ./mvnw clean install $MVN_ARGS
+  else
+    mvn clean install $MVN_ARGS
+  fi
+
+  fix-permissions ./
+  cp ./target/*.jar ../mods/
+elif [ -f "./build.gradle" ]; then
+  echo "Running './gradlew ${GRADLE_ARGS}'"
+  ./gradlew install ${GRADLE_ARGS}
+
+  fix-permissions ./
+  cp ./build/libs/*.jar ../mods/
 fi
-
-fix-permissions ./
-
-mkdir /opt/app-root/mods/
-cp ./target/*.jar /opt/app-root/mods/


### PR DESCRIPTION
@vorburger basic gradle support
Test by running:
```
$> make
$> s2i build https://github.com/vorburger/minecraft-storeys-maker.git edewit/minecraft-sponge-plugin-s2i minecraft-sample-plugin
```
This will fail because it can't find the `*.jar` file